### PR TITLE
Add cross-compilation support.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
     - pytest = py.test:main
 
 requirements:
-  build:
+  host:
     - pip
     - python
     - setuptools
@@ -59,3 +59,4 @@ extra:
     - goanpeca
     - nicoddemus
     - ocefpaf
+    - mingwandroid


### PR DESCRIPTION
Change build to host which is recommended when using conda-build 3. 