### PR TITLE
Configure 'rc' branch for release candidates

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+channel_targets:
+  - conda-forge rc


### PR DESCRIPTION
I've pushed a `rc` branch to the feedstock from `master`, not sure if this is correct.

Also I see `6.0.0rc1` is still labeled "main" in https://anaconda.org/conda-forge/pytest, do we need to change the label manually or just merging this takes care of that?