### PR TITLE
Include colorama as dependency explicitly

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv
   python:
@@ -28,6 +28,7 @@ requirements:
     - setuptools >=77
     - setuptools_scm >=6.2.3
   run:
+    - colorama
     - pygments >=2.7.2
     - python >=${{ python_min }}
     - iniconfig >=1.0.1
@@ -46,8 +47,10 @@ tests:
         - ${{ python_min }}.*
   - requirements:
       run:
+        - pip
         - python ${{ python_min }}.*
     script:
+      - pip check
       - pytest -h
 
 about:


### PR DESCRIPTION
Ideally it should only be included on Windows, however we want to keep the feedstock `noarch`.

Fixes #205

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
